### PR TITLE
Change wildcard character

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 # BrdlGuesser
 ## Description
-Guess the possible BRDL answers given an optional pattern as a starting point. Use one or more asterisks (`*`) as single-letter wildcards. Some letters can be excluded from the matching species Alpha codes using the -x|--exclude option. Conversely, some letters can be included in all the matching species Alpha codes using the -i|--include option. Use the -d|--dump option to display all of the possible BRDL answers.
+Guess the possible BRDL answers given an optional pattern as a starting point. Use one or more underscores (`_`) as single-letter wildcards. Some letters can be excluded from the matching species Alpha codes using the -x|--exclude option. Conversely, some letters can be included in all the matching species Alpha codes using the -i|--include option. Use the -d|--dump option to display all of the possible BRDL answers.
 
 One of the -d|--dump, -i|--include, -p|--pattern, or -x|--exclude options is required. If -p is given, it overrides any -d option.
 
 **NOTES:**
 * Both the search pattern and the letters to be included and excluded can be given as uppercase or lowercase, and will still match.
 * The same letter cannot appear in both the exclusion and inclusion lists.
-* To prevent the shell from interpreting any asterisks in your pattern, enclose the pattern with single quotes.
 
 ## Examples
 ### Display a single, matching BRDL solution
@@ -18,7 +17,7 @@ shell> brdlGuesser.pl -p BBMA
 
 ### Display BRDL solutions that match a pattern
 ```
-shell> brdlGuesser.pl -p 'R**L'
+shell> brdlGuesser.pl -p R__L
    1. RFBL: Red-flanked Bluetail
    2. RWBL: Red-winged Blackbird
    3. RUBL: Rusty Blackbird
@@ -26,7 +25,7 @@ shell> brdlGuesser.pl -p 'R**L'
 
 ### Display BRDL solutions that match a pattern but do not contain some letters
 ```
-shell> brdlGuesser.pl -p 'G*A*' -x MOS
+shell> brdlGuesser.pl -p G_A_ -x MOS
    1. GRAP: Gray Partridge
    2. GRAF: Gray Francolin
    3. GBAN: Groove-billed Ani
@@ -40,7 +39,7 @@ shell> brdlGuesser.pl -p 'G*A*' -x MOS
 
 ### Display BRDL solutions that match a pattern and contain certain letters
 ```
-shell> brdlGuesser.pl -p 'G*A*' -i TW
+shell> brdlGuesser.pl -p G_A_ -i TW
    1. GBAT: Gray-backed Tern
    2. GRAW: Gray Wagtail
 ```


### PR DESCRIPTION
Changed wildcard character from asterisk ('*') to underscore('_') to improve usability. This way, there is no need to quote the search pattern to prevent the shell from doing file name matching.